### PR TITLE
Fix CPU temp when returned value is not an integer in get_hdd_temp.sh

### DIFF
--- a/get_hdd_temp.sh
+++ b/get_hdd_temp.sh
@@ -68,8 +68,7 @@ if [ "$use_ipmi" -eq 0 ]; then
   printf '=== CPU (%s) ===\n' "$cpucores"
   cpucores=$((cpucores - 1))
   for core in $(seq 0 $cpucores); do
-    temp=$(sysctl -n dev.cpu."$core".temperature)
-    temp=$(echo $temp | sed 's/\..*$//g')
+    temp=$(sysctl -n dev.cpu."$core".temperature|sed 's/\..*$//g')
     if [ "$temp" -lt 0 ]; then
       temp="--n/a--"
     else
@@ -84,7 +83,6 @@ else
   printf '=== CPU (%s) ===\n' "$cpucores"
   if [ "$cpucores" -eq 1 ]; then
     temp=$("$ipmitool" -I lanplus -H "$ipmihost" -U "$ipmiuser" -f "$ipmipwfile" sdr elist all | grep "CPU Temp" | awk '{print $10}')
-    temp=$(echo $temp | sed 's/\..*$//g')
     if [ "$temp" -lt 0 ]; then
        temp="-n/a-"
     else
@@ -94,7 +92,6 @@ else
   else
     for core in $(seq 1 "$cpucores"); do
       temp=$("$ipmitool" -I lanplus -H "$ipmihost" -U "$ipmiuser" -f "$ipmipwfile" sdr elist all | grep "CPU${core} Temp" | awk '{print $10}')
-      temp=$(echo $temp | sed 's/\..*$//g')
       if [ "$temp" -lt 0 ]; then
          temp="-n/a-"
        else

--- a/get_hdd_temp.sh
+++ b/get_hdd_temp.sh
@@ -69,6 +69,7 @@ if [ "$use_ipmi" -eq 0 ]; then
   cpucores=$((cpucores - 1))
   for core in $(seq 0 $cpucores); do
     temp=$(sysctl -n dev.cpu."$core".temperature)
+    temp=$(echo $temp | sed 's/\..*$//g')
     if [ "$temp" -lt 0 ]; then
       temp="--n/a--"
     else
@@ -83,6 +84,7 @@ else
   printf '=== CPU (%s) ===\n' "$cpucores"
   if [ "$cpucores" -eq 1 ]; then
     temp=$("$ipmitool" -I lanplus -H "$ipmihost" -U "$ipmiuser" -f "$ipmipwfile" sdr elist all | grep "CPU Temp" | awk '{print $10}')
+    temp=$(echo $temp | sed 's/\..*$//g')
     if [ "$temp" -lt 0 ]; then
        temp="-n/a-"
     else
@@ -92,6 +94,7 @@ else
   else
     for core in $(seq 1 "$cpucores"); do
       temp=$("$ipmitool" -I lanplus -H "$ipmihost" -U "$ipmiuser" -f "$ipmipwfile" sdr elist all | grep "CPU${core} Temp" | awk '{print $10}')
+      temp=$(echo $temp | sed 's/\..*$//g')
       if [ "$temp" -lt 0 ]; then
          temp="-n/a-"
        else


### PR DESCRIPTION
On my system the cpu temp is not reported as an integer.

freenas# sysctl -n dev.cpu.0.temperature
34.0C
freenas# sysctl -n dev.cpu.1.temperature
34.0C
freenas# dmidecode -t system
# dmidecode 3.0
Scanning /dev/mem for entry point.
SMBIOS 2.7 present.

Handle 0x0100, DMI type 1, 27 bytes
System Information
        Manufacturer: HP
        Product Name: ProLiant MicroServer Gen8
        Version: Not Specified
        Serial Number: xxx
        UUID: xxx
        Wake-up Type: Power Switch
        SKU Number: 712318-421
        Family: ProLiant