### PR TITLE
Various fixes - see details

### DIFF
--- a/get_hdd_temp.sh
+++ b/get_hdd_temp.sh
@@ -132,8 +132,18 @@ for drive in $drives; do
     product=$(echo "$smart_data" | egrep "^Product: " | sed -e 's/Product:[[:space:]]*//')
     drive_info="$vendor $product"
   fi
-　
-　
+
+  type=$(echo "$smart_data" | grep 'SATA Version is:  ' | sed -E 's/^SATA Version is:  (SATA [0-9]\.[0-9]), ([0-9]\.[0-9]) G.*$/\1 [\2G\/s]/g' | sed -E 's/\.0G/G/g')
+  if [ -z "$type" ]; then
+    type=$(echo "$smart_data" | grep 'Transport protocol:   SAS' | sed -E 's/^Transport protocol:   (SAS.*)$/\1/g')
+  fi
+  if [ -z "$type" ]; then
+    type=$(echo "$smart_data" | grep -i 'nvm')
+    if [ -n "$type" ]; then
+      type='NVME'
+    fi
+  fi
+  
   serial=$(echo "$smart_data" | grep -i "Serial Number" | awk '{print $3}')
 　
   capacity_text=$(echo "$smart_data" | grep "User Capacity" | sed -E 's/^User Capacity:.*\[([0-9a-zA-Z .]+)\][[:space:]]*$/\1/g')
@@ -163,5 +173,5 @@ for drive in $drives; do
     temp="${temp}C"
   fi
 　
-  printf '%6.6s: %5s    %5s%-3s    %-20.20s %s\n' "$(basename "$drive")" "$temp" "$capacity_val" "$capacity_unit" "$serial" "$drive_info"
+  printf '%6.6s: %5s    %5s%-3s    %-18s %-20.20s %s\n' "$(basename "$drive")" "$temp" "$capacity_val" "$capacity_unit" "$type" "$serial" "$drive_info"
 done


### PR DESCRIPTION
I had a lot of issues with this script as it stood, on my system (FreeNAS 11.0-U4 with NVMe SAS and SATA all in use, some direct connected and some via LSI 9211 HBA. Board = Supermicro). This script fixes them, and with luck, also shouldn't break existing output. 

Issues fixed:

* Device names logic will give nvd for NVMe storage, but smartctl can't interrogate nvd, it interrogates the nvme device instead
* smartctl seems to need to interrogate /dev/name not just name, in some cases (NVMe)
* Field formatting of capacity can be improved - trailing zero decimals .00 is hard on the eye
* Often, data isn't given, because it could appear with other names which should be checked. More "if [ -z "$NAME ]" is needed
* Logic interrogates smartctl multiple times per device - we only need to do it once (output it to a string, then echo and awk/sed/grep the string contents, don't call smartctl again)