### PR TITLE
Prevent wrapping and linebreaks on whitespace

### DIFF
--- a/smart_report.sh
+++ b/smart_report.sh
@@ -60,7 +60,7 @@ Content-Type: multipart/mixed; boundary=\"$boundary\"
 Content-Type: text/html; charset=\"US-ASCII\"
 Content-Transfer-Encoding: 7bit
 Content-Disposition: inline
-<html><head></head><body><pre style=\"font-size:14px\">" > ${logfile}
+<html><head></head><body><pre style=\"font-size:14px; white-space:pre\">" > ${logfile}
 
 ###### summary ######
 (


### PR DESCRIPTION
Some "responsive" web e-mail clients are quite aggressive and wrap the text within \<pre> tags.  I ran into this with the Yahoo! mail client on Android.  This PR prevents this issue.