### PR TITLE
inte 545s fixes

### DIFF
--- a/get_hdd_temp.sh
+++ b/get_hdd_temp.sh
@@ -114,6 +114,9 @@ for drive in $drives; do
   capacity=$("$smartctl" -i "$drive" | grep "User Capacity" | awk '{print $5 $6}')
   temp=$("$smartctl" -A "$drive" | grep "194 Temperature" | awk '{print $10}')
   if [ -z "$temp" ]; then
+    temp=$("$smartctl" -A "$drive" | grep "190 Temperature_Case" | awk '{print $10}')
+  fi
+  if [ -z "$temp" ]; then
     temp=$("$smartctl" -A "$drive" | grep "190 Airflow_Temperature" | awk '{print $10}')
   fi
   if [ -z "$temp" ]; then

--- a/smart_report.sh
+++ b/smart_report.sh
@@ -115,8 +115,10 @@ if [ $SATA_count -gt 0 ]; then
     -v lastTestHours="$lastTestHours" '
     /Serial Number:/{serial=$3}
     /190 Airflow_Temperature/{temp=$10}
+    /190 Temperature_Case/{temp=$10}
     /194 Temperature/{temp=$10}
     /Power_On_Hours/{split($10,a,"+");sub(/h/,"",a[1]);onHours=a[1];}
+    /Power_Cycle_Count/{startStop=$10}
     /Start_Stop_Count/{startStop=$10}
     /Spin_Retry_Count/{spinRetry=$10}
     /Reallocated_Sector/{reAlloc=$10}


### PR DESCRIPTION
Add checks for some additional smart attibutes so scripts will work with intel 545s ssds too.

SMART example, it has **Power_Cycle_Count** but **Start_Stop_Count** is missing and there is **190 Temperature_Case** instead of **190 Airflow_Temperature**
```
########## Intel 545s Series SSDs

SMART overall-health self-assessment test result: PASSED

ID# ATTRIBUTE_NAME          FLAG     VALUE WORST THRESH TYPE      UPDATED  WHEN_FAILED RAW_VALUE
  5 Reallocated_Sector_Ct   0x0032   100   100   000    Old_age   Always       -       0
  9 Power_On_Hours          0x0032   100   100   000    Old_age   Always       -       15259
 12 Power_Cycle_Count       0x0032   100   100   000    Old_age   Always       -       132
170 Unknown_Attribute       0x0033   100   100   010    Pre-fail  Always       -       0
171 Program_Fail_Count      0x0032   100   100   000    Old_age   Always       -       0
172 Erase_Fail_Count        0x0032   100   100   000    Old_age   Always       -       0
173 Unknown_Attribute       0x0033   099   099   005    Pre-fail  Always       -       68722491397
174 Unexpect_Power_Loss_Ct  0x0032   100   100   000    Old_age   Always       -       61
183 SATA_Downshift_Count    0x0032   100   100   000    Old_age   Always       -       0
184 End-to-End_Error        0x0033   100   100   090    Pre-fail  Always       -       0
187 Reported_Uncorrect      0x0032   100   100   000    Old_age   Always       -       0
190 Temperature_Case        0x0032   028   042   000    Old_age   Always       -       28 (Min/Max 20/42)
192 Unsafe_Shutdown_Count   0x0032   100   100   000    Old_age   Always       -       61
199 CRC_Error_Count         0x0032   100   100   000    Old_age   Always       -       0
225 Host_Writes_32MiB       0x0032   100   100   000    Old_age   Always       -       159085
226 Workld_Media_Wear_Indic 0x0032   100   100   000    Old_age   Always       -       0
227 Workld_Host_Reads_Perc  0x0032   100   100   000    Old_age   Always       -       0
228 Workload_Minutes        0x0032   100   100   000    Old_age   Always       -       0
232 Available_Reservd_Space 0x0033   100   100   010    Pre-fail  Always       -       0
233 Media_Wearout_Indicator 0x0032   097   097   000    Old_age   Always       -       0
236 Unknown_Attribute       0x0032   097   097   000    Old_age   Always       -       0
241 Host_Writes_32MiB       0x0032   100   100   000    Old_age   Always       -       159085
242 Host_Reads_32MiB        0x0032   100   100   000    Old_age   Always       -       170728
249 NAND_Writes_1GiB        0x0032   100   100   000    Old_age   Always       -       3219
252 Unknown_Attribute       0x0032   100   100   000    Old_age   Always       -       16
```